### PR TITLE
Integrate Continuum sequencer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 - **The audit process is [here](https://github.com/raydium-io/raydium-docs/tree/master/audit)**
 - **The dev document is [here](https://github.com/raydium-io/raydium-docs/tree/master/dev-resources)**
 
+### Continuum Integration
+
+This fork requires all swap transactions to follow an order list signed by the
+off-chain **Continuum Sequencer**. The sequencer uploads a hash of the ordered
+swaps which the on-chain program verifies before executing each swap. Liquidity
+provider deposit and withdraw flows remain unchanged.
+
 ## Environment Setup
 1. Install [Rust](https://www.rust-lang.org/tools/install).
 2. Install [Solana](https://docs.solana.com/cli/install-solana-cli-tools) and then run `solana-keygen new` to create a keypair at the default location.

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1015,6 +1015,50 @@ impl GetSwapBaseOutData {
     }
 }
 
+/// Sequencer order list account
+#[cfg_attr(feature = "client", derive(Debug))]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Default, PartialEq)]
+pub struct SequencerOrders {
+    /// Hash of the submitted order list
+    pub orders_hash: [u8; 32],
+    /// Next order index expected to be executed
+    pub next_index: u64,
+}
+impl_loadable!(SequencerOrders);
+
+impl SequencerOrders {
+    #[inline]
+    pub fn load_mut_checked<'a>(
+        account: &'a AccountInfo,
+        program_id: &Pubkey,
+    ) -> Result<RefMut<'a, Self>, ProgramError> {
+        if account.owner != program_id {
+            return Err(AmmError::InvalidOwner.into());
+        }
+        if account.data_len() != size_of::<Self>() {
+            return Err(AmmError::ExpectedAccount.into());
+        }
+        let data = Self::load_mut(account)?;
+        Ok(data)
+    }
+
+    #[inline]
+    pub fn load_checked<'a>(
+        account: &'a AccountInfo,
+        program_id: &Pubkey,
+    ) -> Result<Ref<'a, Self>, ProgramError> {
+        if account.owner != program_id {
+            return Err(AmmError::InvalidOwner.into());
+        }
+        if account.data_len() != size_of::<Self>() {
+            return Err(AmmError::ExpectedAccount.into());
+        }
+        let data = Self::load(account)?;
+        Ok(data)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
## Summary
- introduce `SequencerOrders` account and handler stubs
- add new sequencer-based swap instructions
- store default Continuum sequencer id
- document Continuum integration in README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686ac2e35c888332bd281301933ec99c