### PR TITLE
Simulate swaps and resequence failed transactions

### DIFF
--- a/continuum-relayer/Cargo.toml
+++ b/continuum-relayer/Cargo.toml
@@ -40,3 +40,6 @@ tower = "0.4"
 
 # Metrics
 prometheus = "0.13"
+
+[dev-dependencies]
+tempfile = "3"

--- a/continuum-relayer/src/main.rs
+++ b/continuum-relayer/src/main.rs
@@ -175,7 +175,7 @@ async fn swap_handler(
         .map_err(|_| StatusCode::BAD_REQUEST)?;
     
     // Execute swap
-    match state.swap_executor.execute_swap(request).await {
+    match state.swap_executor.execute_swap(request, None).await {
         Ok(response) => Ok(Json(response)),
         Err(e) => {
             error!("Swap execution failed: {:?}", e);
@@ -205,18 +205,32 @@ async fn sequence_monitor_task(state: RelayerState) {
 
 async fn process_pending_swaps(state: &RelayerState) -> Result<()> {
     let mut tracker = state.sequence_tracker.write().await;
-    
+
     // Get on-chain sequence
     let fifo_state_pubkey = get_fifo_state_pubkey();
     let account_data = state.rpc_client.get_account(&fifo_state_pubkey)?;
-    
+
     if account_data.data.len() >= 16 {
         let current_seq = u64::from_le_bytes(
             account_data.data[8..16].try_into().unwrap()
         );
         tracker.update_on_chain_sequence(current_seq)?;
     }
-    
+
+    // Retrieve swaps that are ready to be processed
+    let ready = tracker.get_ready_swaps();
+    drop(tracker);
+
+    for (seq, request) in ready.into_iter() {
+        if let Err(e) = state
+            .swap_executor
+            .execute_swap(request, Some(seq))
+            .await
+        {
+            warn!("Failed to send swap sequence {}: {:?}", seq, e);
+        }
+    }
+
     Ok(())
 }
 

--- a/continuum-relayer/src/sequence_tracker.rs
+++ b/continuum-relayer/src/sequence_tracker.rs
@@ -3,6 +3,12 @@ use anyhow::Result;
 use sled::Db;
 use std::collections::VecDeque;
 
+/// Tracks the sequence number used for FIFO ordering and maintains
+/// a queue of pending swaps.  The `current_sequence` represents the
+/// latest confirmed sequence on-chain.  `pending_swaps` holds swaps
+/// that have been assigned a sequence but have not yet been
+/// successfully sent.
+
 pub struct SequenceTracker {
     db: Db,
     current_sequence: u64,
@@ -12,50 +18,111 @@ pub struct SequenceTracker {
 impl SequenceTracker {
     pub fn new(db_path: &str) -> Result<Self> {
         let db = sled::open(db_path)?;
-        
+
         // Load last known sequence from database
         let current_sequence = if let Some(seq_bytes) = db.get("current_sequence")? {
             u64::from_le_bytes(seq_bytes.as_ref().try_into()?)
         } else {
             0
         };
-        
+
         Ok(Self {
             db,
             current_sequence,
             pending_swaps: VecDeque::new(),
         })
     }
-    
+
     pub fn get_current_sequence(&self) -> Result<u64> {
         Ok(self.current_sequence)
     }
-    
+
+    /// Get the next sequence to be used.  This takes into account any
+    /// pending swaps that have already reserved a sequence but haven't
+    /// been processed yet.
     pub fn get_next_sequence(&self) -> u64 {
-        self.current_sequence + 1
+        match self.pending_swaps.back() {
+            Some((seq, _)) => seq + 1,
+            None => self.current_sequence + 1,
+        }
     }
-    
+
     pub fn get_pending_count(&self) -> usize {
         self.pending_swaps.len()
     }
-    
+
     pub fn update_on_chain_sequence(&mut self, seq: u64) -> Result<()> {
         self.current_sequence = seq;
-        
+
         // Persist to database
         self.db.insert("current_sequence", &seq.to_le_bytes())?;
-        
+
         Ok(())
     }
-    
+
     pub fn add_pending_swap(&mut self, seq: u64, request: SwapRequest) -> Result<()> {
         self.pending_swaps.push_back((seq, request));
         Ok(())
     }
-    
+
+    /// Remove a pending swap that has been successfully processed.
+    pub fn remove_pending_swap(&mut self, seq: u64) {
+        if let Some(pos) = self.pending_swaps.iter().position(|(s, _)| *s == seq) {
+            self.pending_swaps.remove(pos);
+        }
+    }
+
+    /// Resequence the queue after a failure.  `failed_seq` is the sequence that
+    /// failed. If `failed_request` is `Some`, the swap will be retried; otherwise
+    /// it will be dropped. All subsequent pending swaps are requeued with newly
+    /// assigned sequence numbers.
+    pub fn requeue_after_failure(
+        &mut self,
+        failed_seq: u64,
+        failed_request: Option<SwapRequest>,
+    ) -> Result<()> {
+        // Reset the current sequence to the last successfully processed value.
+        if failed_seq > 0 {
+            self.current_sequence = failed_seq - 1;
+        } else {
+            self.current_sequence = 0;
+        }
+
+        // Collect swaps to requeue. Start with any provided failed request.
+        let mut to_requeue: Vec<SwapRequest> = Vec::new();
+        if let Some(req) = failed_request {
+            to_requeue.push(req);
+        }
+
+        while let Some((seq, req)) = self.pending_swaps.pop_front() {
+            if seq == failed_seq {
+                // Drop the failed request if it was already queued and no
+                // explicit retry request was supplied.
+                if to_requeue.is_empty() {
+                    // no retry; skip
+                } else {
+                    // retry already included from parameter, skip original
+                }
+            } else if seq > failed_seq {
+                to_requeue.push(req);
+            } else {
+                // Swaps with lower sequence remain in the queue.
+                self.pending_swaps.push_back((seq, req));
+            }
+        }
+
+        // Assign new sequences sequentially and push back onto the queue.
+        for req in to_requeue.into_iter() {
+            let seq = self.get_next_sequence();
+            self.pending_swaps.push_back((seq, req));
+        }
+
+        Ok(())
+    }
+
     pub fn get_ready_swaps(&mut self) -> Vec<(u64, SwapRequest)> {
         let mut ready = Vec::new();
-        
+
         while let Some((seq, _)) = self.pending_swaps.front() {
             if *seq == self.current_sequence + 1 {
                 if let Some(swap) = self.pending_swaps.pop_front() {
@@ -65,7 +132,76 @@ impl SequenceTracker {
                 break;
             }
         }
-        
+
         ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn dummy_request() -> SwapRequest {
+        SwapRequest {
+            user_pubkey: String::new(),
+            pool_id: String::new(),
+            amount_in: 1,
+            minimum_amount_out: 1,
+            token_a_account: String::new(),
+            token_b_account: String::new(),
+            is_a_to_b: true,
+        }
+    }
+
+    fn tracker() -> SequenceTracker {
+        let dir = TempDir::new().unwrap();
+        SequenceTracker::new(dir.path().to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn simulation_failure_removes_and_resequences() {
+        let mut tracker = tracker();
+        let req1 = dummy_request();
+        let seq1 = tracker.get_next_sequence();
+        tracker.add_pending_swap(seq1, req1).unwrap();
+        let req2 = dummy_request();
+        let seq2 = tracker.get_next_sequence();
+        tracker.add_pending_swap(seq2, req2.clone()).unwrap();
+
+        // Simulate failure for first swap; drop it and resequence others
+        tracker.requeue_after_failure(seq1, None).unwrap();
+
+        let ready = tracker.get_ready_swaps();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, 1); // second swap reassigned to sequence 1
+    }
+
+    #[test]
+    fn send_failure_resequences_queue() {
+        let mut tracker = tracker();
+        let req1 = dummy_request();
+        let req2 = dummy_request();
+        let seq1 = tracker.get_next_sequence();
+        tracker.add_pending_swap(seq1, req1.clone()).unwrap();
+        let seq2 = tracker.get_next_sequence();
+        tracker.add_pending_swap(seq2, req2.clone()).unwrap();
+
+        // Pop the first swap as if it's being processed
+        let ready = tracker.get_ready_swaps();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, 1);
+
+        // Send failure for seq1; requeue it along with subsequent swaps
+        tracker.requeue_after_failure(seq1, Some(req1)).unwrap();
+
+        let ready_after = tracker.get_ready_swaps();
+        assert_eq!(ready_after.len(), 1);
+        assert_eq!(ready_after[0].0, 1); // first swap retried
+
+        tracker.update_on_chain_sequence(1).unwrap();
+        let ready2 = tracker.get_ready_swaps();
+        assert_eq!(ready2.len(), 1);
+        assert_eq!(ready2[0].0, 2); // second swap reassigned
     }
 }

--- a/continuum-relayer/src/swap_executor.rs
+++ b/continuum-relayer/src/swap_executor.rs
@@ -1,22 +1,21 @@
 use crate::{
     errors::RelayerError,
+    raydium_accounts::{get_mock_pool_accounts, load_pool_accounts, RaydiumPoolAccounts},
     sequence_tracker::SequenceTracker,
-    raydium_accounts::{RaydiumPoolAccounts, load_pool_accounts, get_mock_pool_accounts},
-    SwapRequest, SwapResponse,
-    CONTINUUM_PROGRAM_ID, RAYDIUM_AMM_V4,
+    SwapRequest, SwapResponse, CONTINUUM_PROGRAM_ID, RAYDIUM_AMM_V4,
 };
 use anyhow::Result;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    compute_budget::ComputeBudgetInstruction,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
-    compute_budget::ComputeBudgetInstruction,
-    commitment_config::CommitmentConfig,
 };
-use spl_token::instruction::approve_checked;
 use spl_associated_token_account::get_associated_token_address;
+use spl_token::instruction::approve_checked;
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -38,76 +37,68 @@ impl SwapExecutor {
             sequence_tracker,
         }
     }
-    
+
     pub async fn execute_swap(
         &self,
         request: SwapRequest,
+        assigned_seq: Option<u64>,
     ) -> Result<SwapResponse> {
         // Parse pubkeys
         let user_pubkey = Pubkey::from_str(&request.user_pubkey)?;
         let pool_id = Pubkey::from_str(&request.pool_id)?;
         let token_a_account = Pubkey::from_str(&request.token_a_account)?;
         let token_b_account = Pubkey::from_str(&request.token_b_account)?;
-        
-        // Get next sequence
-        let mut tracker = self.sequence_tracker.write().await;
-        let next_seq = tracker.get_next_sequence();
-        drop(tracker); // Release lock early
-        
+
         // Load pool accounts
         let pool_accounts = load_pool_accounts(&pool_id)
             .ok_or_else(|| anyhow::anyhow!("Pool not found: {}", pool_id))?;
-        
+
         // Determine source and destination
         let (source_account, dest_account, source_mint, dest_mint) = if request.is_a_to_b {
             (
-                token_a_account, 
+                token_a_account,
                 token_b_account,
                 Pubkey::from_str("Fk3i45btpZTU1a1npiNvd7my7q67kNnPsYd11Qs98RJm")?, // CONT mint
                 Pubkey::from_str("4QHAYf1fEfJA57WcEuN8FEZkWJiRx9G2uDNF5RQoKrzp")?, // FIFO mint
             )
         } else {
             (
-                token_b_account, 
+                token_b_account,
                 token_a_account,
                 Pubkey::from_str("4QHAYf1fEfJA57WcEuN8FEZkWJiRx9G2uDNF5RQoKrzp")?, // FIFO mint
                 Pubkey::from_str("Fk3i45btpZTU1a1npiNvd7my7q67kNnPsYd11Qs98RJm")?, // CONT mint
             )
         };
-        
+
         // Derive PDAs
         let program_id = Pubkey::from_str(CONTINUUM_PROGRAM_ID)?;
-        let (delegate_authority, _) = Pubkey::find_program_address(
-            &[b"delegate", source_account.as_ref()],
-            &program_id,
-        );
-        
-        let (fifo_state, _) = Pubkey::find_program_address(
-            &[b"fifo_state"],
-            &program_id,
-        );
-        
-        let (pool_authority_state, _) = Pubkey::find_program_address(
-            &[b"pool_authority_state", pool_id.as_ref()],
-            &program_id,
-        );
-        
-        let (pool_authority, _) = Pubkey::find_program_address(
-            &[b"pool_authority", pool_id.as_ref()],
-            &program_id,
-        );
-        
-        // Build transaction
+        let (delegate_authority, _) =
+            Pubkey::find_program_address(&[b"delegate", source_account.as_ref()], &program_id);
+
+        let (fifo_state, _) = Pubkey::find_program_address(&[b"fifo_state"], &program_id);
+
+        let (pool_authority_state, _) =
+            Pubkey::find_program_address(&[b"pool_authority_state", pool_id.as_ref()], &program_id);
+
+        let (pool_authority, _) =
+            Pubkey::find_program_address(&[b"pool_authority", pool_id.as_ref()], &program_id);
+
+        // Determine sequence number
+        let actual_seq = match assigned_seq {
+            Some(seq) => seq,
+            None => {
+                let mut tracker = self.sequence_tracker.write().await;
+                let seq = tracker.get_next_sequence();
+                tracker.add_pending_swap(seq, request.clone())?;
+                seq
+            }
+        };
+
+        // Build transaction using the real sequence
         let blockhash = self.rpc_client.get_latest_blockhash()?;
-        let mut transaction = Transaction::new_with_payer(
-            &[],
-            Some(&self.keypair.pubkey()),
-        );
-        
-        // Add compute budget
+        let mut transaction = Transaction::new_with_payer(&[], Some(&self.keypair.pubkey()));
         transaction.add(ComputeBudgetInstruction::set_compute_unit_limit(600_000));
-        
-        // Add approve instruction
+
         let approve_ix = approve_checked(
             &spl_token::id(),
             &source_account,
@@ -116,11 +107,9 @@ impl SwapExecutor {
             &user_pubkey,
             &[],
             request.amount_in,
-            9, // decimals
+            9,
         )?;
         transaction.add(approve_ix);
-        
-        // Build swap instruction
         let swap_ix = self.build_swap_instruction(
             pool_id,
             pool_authority_state,
@@ -132,27 +121,51 @@ impl SwapExecutor {
             delegate_authority,
             request.amount_in,
             request.minimum_amount_out,
-            next_seq,
+            actual_seq,
             pool_accounts,
         )?;
         transaction.add(swap_ix);
-        
-        // Sign and send
         transaction.sign(&[self.keypair.as_ref()], blockhash);
-        
-        let signature = self.rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-            &transaction,
-            CommitmentConfig::confirmed(),
-            Default::default(),
-        )?;
-        
-        Ok(SwapResponse {
-            signature: signature.to_string(),
-            sequence: next_seq,
-            estimated_output: request.minimum_amount_out,
-        })
+
+        // Simulate the transaction
+        let sim_res = self.rpc_client.simulate_transaction(&transaction)?;
+        if sim_res.value.err.is_some() {
+            log::warn!("Swap simulation failed: {:?}", sim_res.value.err);
+            let mut tracker = self.sequence_tracker.write().await;
+            tracker.requeue_after_failure(actual_seq, None)?;
+            return Err(RelayerError::SimulationFailed.into());
+        }
+
+        // Refresh blockhash and resign before sending
+        let blockhash = self.rpc_client.get_latest_blockhash()?;
+        transaction.sign(&[self.keypair.as_ref()], blockhash);
+
+        // Send the transaction
+        match self
+            .rpc_client
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &transaction,
+                CommitmentConfig::confirmed(),
+                Default::default(),
+            ) {
+            Ok(signature) => {
+                let mut tracker = self.sequence_tracker.write().await;
+                tracker.update_on_chain_sequence(actual_seq)?;
+                tracker.remove_pending_swap(actual_seq);
+                Ok(SwapResponse {
+                    signature: signature.to_string(),
+                    sequence: actual_seq,
+                    estimated_output: request.minimum_amount_out,
+                })
+            }
+            Err(e) => {
+                let mut tracker = self.sequence_tracker.write().await;
+                tracker.requeue_after_failure(actual_seq, Some(request))?;
+                Err(e.into())
+            }
+        }
     }
-    
+
     fn build_swap_instruction(
         &self,
         pool_id: Pubkey,
@@ -170,14 +183,14 @@ impl SwapExecutor {
     ) -> Result<Instruction> {
         // Build Raydium swap data
         let raydium_data = self.build_raydium_swap_data(amount_in, minimum_amount_out);
-        
+
         // Build wrapper instruction data
         let mut data = Vec::new();
         data.extend_from_slice(&[237, 180, 80, 103, 107, 172, 187, 137]); // swap_with_pool_authority discriminator
         data.extend_from_slice(&sequence.to_le_bytes());
         data.extend_from_slice(&(raydium_data.len() as u32).to_le_bytes());
         data.extend_from_slice(&raydium_data);
-        
+
         // Build account list
         let mut accounts = vec![
             // Wrapper-specific accounts
@@ -191,18 +204,18 @@ impl SwapExecutor {
             AccountMeta::new_readonly(Pubkey::from_str(RAYDIUM_AMM_V4)?, false),
             AccountMeta::new_readonly(spl_token::id(), false),
         ];
-        
+
         // Add Raydium accounts
         let raydium_accounts = pool_accounts.to_account_metas(source, destination, pool_authority);
         accounts.extend(raydium_accounts);
-        
+
         Ok(Instruction {
             program_id: Pubkey::from_str(CONTINUUM_PROGRAM_ID)?,
             accounts,
             data,
         })
     }
-    
+
     fn build_raydium_swap_data(&self, amount_in: u64, minimum_amount_out: u64) -> Vec<u8> {
         let mut data = Vec::new();
         data.extend_from_slice(&[248, 198, 158, 145, 225, 117, 135, 200]); // Raydium swap discriminator


### PR DESCRIPTION
## Summary
- Simulate user swap transactions after assigning sequence numbers
- Requeue or drop failed swaps and resequence subsequent pending swaps
- Retry pending swaps in background loop and add unit tests for failure cases

## Testing
- `cargo test -p continuum-relayer` *(fails: failed to download dependency anchor-spl: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9714581c833184e9165d1bcfc0d7